### PR TITLE
non-production: monitor Process.waitall results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - Unreleased
+## [0.2.1] - 2024-06-17
 ### Fixed
 - Fixed a bug allowing child process errors to be ignored while rendering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - Unreleased
+### Fixed
+- Fixed a bug allowing child process errors to be ignored while rendering.
+
 ## [0.2.0] - 2024-05-06
 ### Added
 - Added support for passing `--source-repo` flag into command line so that the rendered manifest comments can include a link to the source repository.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,8 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.0)
-    rexml (3.2.6)
+    rexml (3.3.0)
+      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -85,6 +86,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    strscan (3.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kubernetes_template_rendering (0.2.0)
+    kubernetes_template_rendering (0.2.1.pre.dc.7)
       activesupport
       invoca-utils
       jsonnet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kubernetes_template_rendering (0.2.1.pre.dc.7)
+    kubernetes_template_rendering (0.2.1)
       activesupport
       invoca-utils
       jsonnet

--- a/lib/kubernetes_template_rendering/version.rb
+++ b/lib/kubernetes_template_rendering/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KubernetesTemplateRendering
-  VERSION = "0.2.1.pre.dc.7"
+  VERSION = "0.2.1"
 end

--- a/lib/kubernetes_template_rendering/version.rb
+++ b/lib/kubernetes_template_rendering/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KubernetesTemplateRendering
-  VERSION = "0.2.0"
+  VERSION = "0.2.1.pre.dc.7"
 end


### PR DESCRIPTION
Note: I'm not having luck with getting working unit tests for this forked processes path. Decided to cut my losses, test locally, and get the code reviewed.

## [0.2.1]
### Fixed
- Fixed a bug allowing child process errors to be ignored while rendering.

## Demo

### Rendering successfully
```
invocaops_docker (master) > make -j 6 
...
gem exec -g kubernetes_template_rendering -v 0.2.1.pre.dc.7 --prerelease render_templates --rendered_directory=zz-rendered --jsonnet-library-path vendor-jb --makeflags " --jobserver-fds=3,4 -j" templates > log/render.out
transforming staging partial platform 'staging-qa05a' with trace output to log/spp-staging-qa05a-transform.out
transforming staging partial platform 'staging-qa05b' with trace output to log/spp-staging-qa05b-transform.out
find zz-rendered -type f '!' -newer .timestamp-render -print -exec rm {} ';'
```

### Render failing (tested in both single process and forking mode)
```
invocaops_docker (master) > make -j 6
...
gem exec -g kubernetes_template_rendering -v 0.2.1.pre.dc.7 --prerelease render_templates --rendered_directory=zz-rendered --jsonnet-library-path vendor-jb --makeflags " --jobserver-fds=3,4 -j" templates > log/render.out
ERROR:  While executing gem ... (RuntimeError)
    error rendering ResourceSet from templates/data-services/prometheus-rules/definitions.yaml
Jsonnet::EvaluationError: RUNTIME ERROR: field does not exist: teamNameee
	templates/data-services/prometheus-rules/metrics-queue-runtime-prometheusrule.jsonnet:5:15-30	object <anonymous>
...
ERROR:  While executing gem ... (RuntimeError)
    error rendering ResourceSet from templates/data-services/prometheus-rules/definitions.yaml
Jsonnet::EvaluationError: RUNTIME ERROR: field does not exist: teamNameee
	templates/data-services/prometheus-rules/metrics-queue-runtime-prometheusrule.jsonnet:5:15-30	object <anonymous>
...
ERROR:  While executing gem ... (RuntimeError)
    Child process completed with non-zero status: [[31634, #<Process::Status: pid 31634 exit 1>], [31981, #<Process::Status: pid 31981 exit 1>]]
...
make: *** [render] Error 1
```