### PR TITLE
THUND-1062: add us-west-2 (AWS) region mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-06-12
+### Added
+- Added `us-west-2` (AWS) to region mappings for the new us-west-2 production cluster
+
 ## [0.2.5] - 2025-05-08
 ### Fixed
 - Updated `rexml` dependency to avoid security issues

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kubernetes_template_rendering (0.2.5)
+    kubernetes_template_rendering (0.2.6)
       activesupport (< 8)
       invoca-utils
       jsonnet

--- a/lib/kubernetes_template_rendering/resource_set.rb
+++ b/lib/kubernetes_template_rendering/resource_set.rb
@@ -90,6 +90,7 @@ module KubernetesTemplateRendering
       # https://github.com/Invoca/process_settings-production/blob/main/settings/region_discovery/production_regions.yml
       "us-east-1"    => ['aws', "AWS-us-east-1"],
       "us-east-2"    => ['aws', "AWS-us-east-2"],
+      "us-west-2"    => ['aws', "AWS-us-west-2"],
       "us-central1"  => ['gcp', "GCE-us-central1"],
       "us-west2"     => ['gcp', "GCE-us-west2"],
       "eu-central-1" => ['aws', "AWS-eu-central-1"],
@@ -113,6 +114,11 @@ module KubernetesTemplateRendering
         "primary" => "us-east-2a",
         "secondary" => "us-east-2b",
         "tertiary" => "us-east-2c"
+      },
+      "us-west-2" => {
+        "primary" => "us-west-2a",
+        "secondary" => "us-west-2b",
+        "tertiary" => "us-west-2c"
       },
       "us-central1" => {
         "primary" => "us-central1-a",

--- a/lib/kubernetes_template_rendering/version.rb
+++ b/lib/kubernetes_template_rendering/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KubernetesTemplateRendering
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end


### PR DESCRIPTION
## Purpose
Part of [THUND-1062](https://invoca.atlassian.net/browse/THUND-1062): enable the new AWS us-west-2 production cluster. The renderer raises `no CLOUD_REGION_TO_PROVIDER_AND_DATACENTER entry found` for unknown regions, so this must ship (and be bumped in invocaops_docker's Gemfile.lock) before any invocaops_docker `definitions.yaml` can list `us-west-2`.

## Changes
- `us-west-2` → `['aws', "AWS-us-west-2"]` in `CLOUD_REGION_TO_PROVIDER_AND_DATACENTER`
- `us-west-2a/b/c` deploy-group AZ mappings in `AVAILABILITY_ZONE_FOR_DEPLOY_GROUP`
- Version 0.2.6, CHANGELOG entry

Mirrors the existing us-east-2 entries (region names match RegionDiscovery in process_settings-production). `bundle exec rspec`: 40 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[THUND-1062]: https://invoca.atlassian.net/browse/THUND-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ